### PR TITLE
improve connection validation

### DIFF
--- a/ruby/lib/metasploit/aggregator.rb
+++ b/ruby/lib/metasploit/aggregator.rb
@@ -105,7 +105,11 @@ module Metasploit
       end
 
       def available?
-        @client.available(@no_params).answer
+        begin
+          @client.available(@no_params).answer
+        rescue GRPC::Unavailable
+          false # unavailable if client throws exception.
+        end
       end
 
       def sessions


### PR DESCRIPTION
When connection fails or excepts on `.available?` call catch and report `false`