### PR TITLE
catch GRPC::Unavailable in listener thread to stop processing

### DIFF
--- a/ruby/lib/metasploit/aggregator.rb
+++ b/ruby/lib/metasploit/aggregator.rb
@@ -361,6 +361,7 @@ module Metasploit
           while true
             request = @local_server.request(uuid)
             # TODO: with this in place we can just get the request queue and pop each item to process and forward
+            sleep 0.1
             unless request.nil?
               body = ""
               body = request.body unless request.body.nil?


### PR DESCRIPTION
Rescue connection Unavailable in listener thread as this is a signal that the server is no longer reachable.

This may impact service reliability over time and further action may need to be taken by client when server become available again.  For now hold expectation of a reliable connection.